### PR TITLE
added new page to guide for parameters

### DIFF
--- a/_docs/database.md
+++ b/_docs/database.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: "Database Connection"
-order: 12
+order: 13
 ---
 
 Kemal is `Database Agnostic`. It doesn't enforce any database and / or libraries.

--- a/_docs/deployment.md
+++ b/_docs/deployment.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: "Deployment"
-order: 15
+order: 16
 ---
 
 ## Heroku

--- a/_docs/parameters.md
+++ b/_docs/parameters.md
@@ -1,0 +1,62 @@
+---
+layout: doc
+title: HTTP Parameters
+order: 11
+---
+
+When passing data through an HTTP request, you will often need to use query parameters, or post parameters depending on which HTTP method you're using.
+
+### URL Parameters
+Kemal allows you to use variables in your route path as placeholders for passing data. To access URL parameters, you use `env.params.url`.
+
+```ruby
+# Matches /hello/kemal
+get "/hello/:name" do |env|
+  name = env.params.url["name"]
+  "Hello back to #{name}"
+end
+
+# Matches /users/1
+get "/users/:id" do |env|
+  id = env.params.url["id"]
+  "Found user #{id}"
+end
+```
+
+### Query Parameters
+To access query parameters, you use `env.params.query`.
+
+```ruby
+# Matches /resize?width=200&height=200
+get "/resize" do |env|
+  width = env.params.query["width"]
+  height = env.params.query["height"]
+end
+```
+
+### POST Parameters
+Kemal has a few options for accessing post parameters. You can easily access JSON payload from the params, or through the standard post body.
+
+For JSON params, you use `env.params.json`.
+For body params, you use `env.params.body`.
+
+```ruby
+# The request content type needs to be application/json
+# The payload
+# {"name": "Serdar", "likes": ["Ruby", "Crystal"]}
+post "/json_params" do |env|
+  name = env.params.json["name"].as(String)
+  likes = env.params.json["likes"].as(Array)
+  "#{name} likes #{likes.join(",")}"
+end
+
+# Using a standard post body
+# name=Serdar&likes[]=Ruby&likes[]=Crystal
+post "/body_params" do |env|
+  name = env.params.body["name"].as(String)
+  likes = env.params.body.fetch_all("likes[]").as(Array)
+  "#{name} likes #{likes.join(",")}"
+end
+```
+
+**NOTE:** For Array or Hash like params, you will need to use the `fetch_all` method. You can read more about [HTTP::Params](https://crystal-lang.org/api/HTTP/Params.html) from the Crystal docs.

--- a/_docs/parameters.md
+++ b/_docs/parameters.md
@@ -51,12 +51,12 @@ post "/json_params" do |env|
 end
 
 # Using a standard post body
-# name=Serdar&likes[]=Ruby&likes[]=Crystal
+# name=Serdar&likes=Ruby&likes=Crystal
 post "/body_params" do |env|
   name = env.params.body["name"].as(String)
-  likes = env.params.body.fetch_all("likes[]").as(Array)
+  likes = env.params.body["likes"].as(Array)
   "#{name} likes #{likes.join(",")}"
 end
 ```
 
-**NOTE:** For Array or Hash like params, you will need to use the `fetch_all` method. You can read more about [HTTP::Params](https://crystal-lang.org/api/HTTP/Params.html) from the Crystal docs.
+**NOTE:** For Array or Hash like params, Kemal will group like keys for you. Alternatively, you can use the square bracket notation `likes[]=ruby&likes[]=crystal`. Be sure to access the param name exactly how it was passed. (i.e. `env.params.body["likes[]"]`).

--- a/_docs/sessions.md
+++ b/_docs/sessions.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: Sessions
-order: 11
+order: 12
 ---
 
 Kemal supports Sessions with [kemal-session](https://github.com/kemalcr/kemal-session).

--- a/_docs/ssl.md
+++ b/_docs/ssl.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: "SSL"
-order: 14
+order: 15
 ---
 
 Kemal has built-in and easy to use SSL support.

--- a/_docs/websockets.md
+++ b/_docs/websockets.md
@@ -1,7 +1,7 @@
 ---
 layout: doc
 title: Websockets
-order: 13
+order: 14
 ---
 
 Using Websockets is super easy! By nature Websockets are a bit different than standard Http Request / Response lifecycle.


### PR DESCRIPTION
I placed the sidebar link right after the HTTP Request section moving all others down. 

There is some duplication from the context page, but I believe that the context page can be cleaned up to talk more about the `env.request` and `env.response` objects. That will be a separate PR