### PR TITLE
Fix incorrect unit "hz"

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ Kemal.run
       </div>
     </div>
     <div class="u-mr-top-20">
-      <small>These results were achieved with <strong>wrk</strong> on a Macbook Pro Late 2013. <strong>(2Ghz i7 8GB Ram OS X Yosemite)</strong></small>
+      <small>These results were achieved with <strong>wrk</strong> on a Macbook Pro Late 2013. <strong>(2GHz i7 8GB Ram OS X Yosemite)</strong></small>
     </div>
   </div>
 </div>


### PR DESCRIPTION
From the index page:
> These results were achieved with <strong>wrk</strong> on a Macbook Pro Late 2013. <strong>(2Ghz i7 8GB Ram OS X Yosemite)</strong>

Microscopic correction, but IMHO important:
The case of `hz`! ... `Hz` is the SI unit Hertz; and AFAIC there's generally recognised unit `hz`.

EDIT: And sorry: I am stupendously addicted to BSD wtf's acronyms