### PR TITLE
Change CSRF paramater name in Guide to fit default

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -761,7 +761,7 @@ See [kemal-session](https://github.com/kemalcr/kemal-session) for usage and comp
 To access the CSRF token of the active session you can do the following in your form:
 
 ```erb
-<input type="hidden" name="_csrf" value="<%= env.session.string("csrf") %>">
+<input type="hidden" name="authenticity_token" value="<%= env.session.string("csrf") %>">
 ```
 
 # [WebSockets](#websockets)


### PR DESCRIPTION
The code shown in the guide should fit the default parameter name: https://github.com/kemalcr/kemal-csrf/blob/master/src/kemal-csrf.cr#L14

(Changing the default parameter name is of course also possible, let me know what you think.)