### PR TITLE
cookbook/json-mapping: Change `JSON.mapping` to `JSON::Serializable`

### DIFF
--- a/_cookbook/code/json-mapping/app.cr
+++ b/_cookbook/code/json-mapping/app.cr
@@ -3,10 +3,9 @@ require "json"
 
 # You can use JSON.mapping to directly create an object from JSON
 class User
-  JSON.mapping(
-    username: String,
-    password: String,
-  )
+  include JSON::Serializable
+
+  property username : String, password : String
 end
 
 post "/" do |env|


### PR DESCRIPTION
`JSON.mapping` is moved to external lib in favor of `JSON::Serializable`
in stdlib from Crystal `0.35`.

Ref: https://crystal-lang.org/2020/06/09/crystal-0.35.0-released.html

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>