### PR TITLE
Update crystal install link

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -5,7 +5,7 @@ title: Kemal - Guide
 
 # [Getting Started](#getting-started)
 
-This guide assumes that you already have Crystal installed. If not, check out the [Crystal installation methods](https://crystal-lang.org/docs/installation/) and come back when you're done.
+This guide assumes that you already have Crystal installed. If not, check out the [Crystal installation methods](https://crystal-lang.org/install/) and come back when you're done.
 
 ### Installing Kemal
 


### PR DESCRIPTION
Install link on crystal-lang.org changed... existing link 404s.