### PR TITLE
added note that halt can only be used inside routes

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -390,6 +390,8 @@ Halt execution with the current context. Returns 200 and an empty response by de
 halt env, status_code: 403, response: "Forbidden"
 ```
 
+*Note:* Halt can only be used inside routes.
+
 ### Custom Errors
 
 You can customize the built-in error pages or even add your own with `error`.

--- a/guide.md
+++ b/guide.md
@@ -390,7 +390,7 @@ Halt execution with the current context. Returns 200 and an empty response by de
 halt env, status_code: 403, response: "Forbidden"
 ```
 
-*Note:* Halt can only be used inside routes.
+*Note:* `halt` can only be used inside routes.
 
 ### Custom Errors
 


### PR DESCRIPTION
Added a note that `halt` can only be used inside routes.

Should close #44 