### PR TITLE
added example of custom auth handler

### DIFF
--- a/_cookbook/code/http-basic-auth/custom-handler.cr
+++ b/_cookbook/code/http-basic-auth/custom-handler.cr
@@ -8,3 +8,5 @@ class CustomAuthHandler < Kemal::BasicAuth::Handler
     super
   end
 end
+
+Kemal.config.auth_handler = CustomAuthHandler

--- a/_cookbook/code/http-basic-auth/custom-handler.cr
+++ b/_cookbook/code/http-basic-auth/custom-handler.cr
@@ -1,0 +1,10 @@
+require "kemal-basic-auth"
+
+class CustomAuthHandler < Kemal::BasicAuth::Handler
+  only ["/dashboard", "/admin"] # routes with basic authorization
+
+  def call(context)
+    return call_next(context) unless only_match?(context)
+    super
+  end
+end

--- a/_cookbook/http_basic_auth.md
+++ b/_cookbook/http_basic_auth.md
@@ -7,4 +7,10 @@ title: HTTP Basic Auth Recipe
 {% include_relative code/http-basic-auth/app.cr %}
 ```
 
+This will add basic authorization to all routes in your application. However, some applications only need authorization on some of its routes. This is something can be easily done by creating a custom authorization handler.
+
+```ruby
+{% include_relative code/http-basic-auth/custom-handler.cr %}
+```
+
 [Source Code](https://github.com/kemalcr/kemalcr.com/tree/master/_cookbook/code/http-basic-auth)


### PR DESCRIPTION
Today I created a PR for kemal-basic-auth which makes it possible to create custom handlers that only adds authorization to specific routes.

This PR adds an example to the cookbook of how to create such handlers.

This PR should only be merged if/when kemalcr/kemal-basic-auth#8 gets merged.