### PR TITLE
added cli section

### DIFF
--- a/_sass/components/_home.scss
+++ b/_sass/components/_home.scss
@@ -149,3 +149,12 @@
   }
 }
 
+.mbtablestyle {
+  border-collapse: collapse;
+
+  > table, td, th {
+    border: 1px solid black;
+	padding: 5px 8px;
+  }
+}
+

--- a/guide.md
+++ b/guide.md
@@ -906,6 +906,18 @@ Run the tests:
 KEMAL_ENV=test crystal spec
 ```
 
+# [CLI](#cli)
+
+A Kemal application accepts a few optional command-line flags:
+
+| Short flag | Long flag              | Description                                   |
+|------------| -----------------------| --------------------------------------------- |
+| `-b HOST`  | `--bind HOST`          | Host to bind (default: 0.0.0.0)               |
+| `-p PORT`  | `--port PORT`          | Port to listen for connection (default: 3000) |
+| `-s`       | `--ssl`                | Enables SSL                                   |
+|            | `--ssl-key-file FILE`  | SSL key file                                  |
+{:.mbtablestyle}
+
 # [SSL](#ssl)
 
 Kemal has built-in and easy to use SSL support.


### PR DESCRIPTION
I noticed going through Kemal's source code that a Kemal application can take a few command-line flags. This PR adds a table with these flags with `short flag`, `long flag` and a `description`.

I'm not sure about the styling of the table and might need someone else to update the scss in `_sass/components/_home.scss` if it needs better styling.