### PR TITLE
fix to guide liquid template syntax error

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -250,9 +250,11 @@ Since Crystal does not allow using variables in macro literals, you need to gene
 another *helper macro* to make the code easier to read and write.
 
 ```ruby
+{% raw %}
 macro my_renderer(filename)
-  render "my/app/view/base/path/#{{{filename}}}.ecr", "my/app/view/base/path/layouts/layout.ecr"
+  render "my/app/view/base/path/#{ {{filename}} }.ecr", "my/app/view/base/path/layouts/layout.ecr"
 end
+{% endraw %}
 ```
 
 And now you can use your new renderer.


### PR DESCRIPTION
On the kemalcr.com website, the following code snippet typo is observed:
![Screen Shot 2022-09-28 at 8 20 16 AM](https://user-images.githubusercontent.com/1561054/192780602-0360dcd9-f5a3-4eeb-b531-27604594f9e1.png)

and when running the site locally via `bundle exec jekyll serve` the following related error is also seen:
![Screen Shot 2022-09-28 at 8 22 06 AM](https://user-images.githubusercontent.com/1561054/192780751-38b7f621-ed7d-4b75-8a26-d28d1f838166.png)

This PR fixed both.