### PR TITLE
add example of how to use custom error

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -406,6 +406,22 @@ error 403 do
 end
 ```
 
+To use a custom `error` you must set the `response.status_code` and then raise a `Kemal::Exceptions::CustomException`.
+
+```ruby
+get "/" do |env|
+  if some_condition
+    env.response.status_code = 403
+    raise Kemal::Exceptions::CustomException.new env
+  end
+  {"message": "Hello Kemal"}.to_json
+end
+
+error 403 do
+  "Access denied"
+end
+```
+
 ### Send File
 
 Send a file with given path and base the MIME type on the file extension


### PR DESCRIPTION
This PR adds an example of how to use a custom error.

I have never used these custom errors before myself because I never really figured out how to use them. It is not clear from the documentation that you have to set the `status_code` and then raise `Kemal::Exceptions::CustomException` and I only found out about this because I saw this issue kemalcr/kemal#622 the other day.