### PR TITLE
Added Media page with downloadable logo and basic usage info

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,3 +42,9 @@ jsarr:
 
 plugins:
   - jemoji
+
+footer_docs:
+  - title: "Getting Started"
+    url: "/guide/#getting-started"
+  - title: "Media"
+    url: "/media"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,15 +1,44 @@
 <footer class="Footer">
   <div class="container">
     <div class="row">
-      <div class="col-sm-12 Footer_copyright">
-        <p>Kemal is developed and maintained by <a href="http://twitter.com/sdogruyol" target="_blank">Serdar Doğruyol</a></p>
+      <div class="col-sm-6">
+        <p>Documentation</p>
+        <nav>
+          <ul>
+            {% for doc in site.footer_docs %}
+            <li>
+              <a href="{{ doc.url | prepend: site.baseurl }}"
+                >{{ doc.title }}</a
+              >
+            </li>
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+      <div class="col-sm-6 Footer_copyright">
+        <p>
+          Kemal is developed and maintained by
+          <a href="http://twitter.com/sdogruyol" target="_blank"
+            >Serdar Doğruyol</a
+          >
+        </p>
         <div>
-          <small>Design by <a href="http://twitter.com/askngdk" target="_blank">Aşkın Gedik</a> and <a href="http://twitter.com/SinanMtl" target="_blank">Sinan Mutlu</a></small>
+          <small
+            >Design by
+            <a href="http://twitter.com/askngdk" target="_blank">Aşkın Gedik</a>
+            and
+            <a href="http://twitter.com/SinanMtl" target="_blank"
+              >Sinan Mutlu</a
+            ></small
+          >
         </div>
       </div>
     </div>
   </div>
 </footer>
 {% for js in site.jsarr %}
-<script type="text/javascript" src="{{ js.name | prepend: site.baseurl }}"></script>
+<script
+  type="text/javascript"
+  src="{{ js.name | prepend: site.baseurl }}"
+></script>
 {% endfor %}

--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -1,23 +1,32 @@
-
 /*
 * Footer
 */
 
-.Footer{
+.Footer {
   padding: 20px 0;
   border-top: 1px solid #e8e8e8;
   font-size: 14px;
   color: #828282;
   text-align: center;
 
-  a{color: #2a7ae2;}
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 
-  &_copyright{padding-top: 20px;}
+  &_copyright {
+    padding-top: 20px;
 
-  @media screen and (min-width: $screen-sm-min){
+    a {
+      color: #2a7ae2;
+    }
+  }
+
+  @media screen and (min-width: $screen-sm-min) {
     text-align: left;
 
-    &_copyright{
+    &_copyright {
       padding-top: 0;
       text-align: right;
     }

--- a/media.md
+++ b/media.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Media
+---
+
+# Media
+
+## Logo
+
+> **NOTE:** Please follow the [guidelines](#guidelines) below when using this material.
+
+![Kemal Logo]({{ site.baseurl }}/img/kemal.png)
+
+[Download logo (PNG)]({{ site.baseurl }}/img/kemal.png){: download="kemal.png" }
+
+---
+
+## Guidelines {#guidelines}
+
+**Acceptable ways to use the Kemal logo and brand:**
+
+- Include it in technical articles, blog posts, or news about Kemal.
+- Display it in conference presentations, academic papers, or community talks.
+- Feature it when showcasing projects you've built with Kemal.
+- Incorporate it into educational content and tutorials.
+- Use it on personal, non-commercial merchandise.
+
+**Please refrain from:**
+
+- Altering the logo's design, colors, or proportions.
+- Commercializing products featuring the logo without permission.
+- Creating combination logos that merge Kemal's branding with your own.
+- Adopting the logo as your primary brand identity.
+- Presenting the logo in ways that imply official endorsement from the Kemal project.


### PR DESCRIPTION
Adds a new `/media` page with:

- Kemal logo available for download
- General usage suggestions based on common OSS practices

This addresses #32, a request to provide a media section for users who want to include the logo in educational content.

The goal is to offer a clear starting point. Maintainers can expand it later with more formats or branding guidelines if needed.


Preview
![footer](https://github.com/user-attachments/assets/e20c1619-6317-4a1b-9c62-e15a477e7dfb)
![media-page](https://github.com/user-attachments/assets/cc23d231-f8c0-46ac-ba25-5d44735d4e37)


