### PR TITLE
Update head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,6 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="keywords" content="">
   <meta name="description" content="{{ site.description }}">
   <link rel="apple-touch-icon" sizes="57x57" href="{{ "/img/favicon/apple-icon-57x57.png" | prepend: site.baseurl }}">
   <link rel="apple-touch-icon" sizes="60x60" href="{{ "/img/favicon/apple-icon-60x60.png" | prepend: site.baseurl }}">


### PR DESCRIPTION
Update based on issue #95 

The outdated and obsolete HTML keywords meta tag has been removed.