### PR TITLE
docs: document the HTTP QUERY method (RFC 10008)

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -10,6 +10,7 @@ title: Kemal - Guide
    - [Using Kemal](#using-kemal)
    - [Running Kemal](#running-kemal)
 2. [Routes](#routes)
+   - [HTTP QUERY Method](#http-query-method)
    - [Kemal::Router (Modular Routing)](#kemal-router-modular-routing)
 3. [HTTP Parameters](#http-parameters)
    - [URL Parameters](#url-parameters)
@@ -183,10 +184,52 @@ end
 delete "/" do
   # Example: Delete user account, remove blog post, clear cache
 end
+
+# QUERY - Read data with the query in the request body (RFC 10008)
+# Use for: Searches and filters that are too large or too structured for a URL
+query "/" do
+  # Example: Faceted product search, geo polygon lookup, long filter lists
+end
 ```
 
 Any **string** returned from a route will output to the browser.
 Routes are matched in the order they are defined. The first route that matches the request is invoked.
+
+### [HTTP QUERY Method](#http-query-method)
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is a safe and idempotent method — like `GET` — that carries the query in the **request body** instead of the URL. It's a good fit when a search is too long, too structured, or too sensitive to sit in a query string.
+
+```crystal
+require "kemal"
+
+query "/search" do |env|
+  # For "Content-Type: application/json"
+  q = env.params.json["q"]?.to_s
+
+  # For "Content-Type: application/x-www-form-urlencoded"
+  # q = env.params.body["q"]?.to_s
+
+  env.json({query: q, results: [] of String})
+end
+
+Kemal.run
+```
+
+Try it with `curl`:
+
+```
+curl -X QUERY http://localhost:3000/search \
+  -H "Content-Type: application/json" \
+  -d '{"q": "crystal"}'
+```
+
+Things to keep in mind:
+
+- `QUERY` is **safe and idempotent**, so the handler must not change server state. Use `POST` when the request has side effects.
+- A `QUERY` request that has a body but **no** `Content-Type` header is rejected with `400` by Kemal, as the RFC requires the content to carry a media type.
+- Deciding whether a query format is supported (`415`), acceptable (`406`), or processable (`422`) is up to your handler. You can advertise the formats you accept with the `Accept-Query` response header.
+- `QUERY` is not a CORS-safelisted method, so browsers always send a preflight request for it.
+- `before_query` / `after_query` filters and `Kemal::Router#query` work like every other verb.
 
 ### [Kemal::Router (Modular Routing)](#kemal-router-modular-routing)
 
@@ -278,6 +321,8 @@ end
 ```
 
 **NOTE:** For Array or Hash like parameters, Kemal will group like keys for you. Alternatively, you can use the square bracket notation `likes[]=ruby&likes[]=crystal`. Be sure to access the param name exactly how it was passed. (i.e. `env.params.body["likes[]"]`).
+
+**NOTE:** `env.params.json` and `env.params.body` work the same way for any method with a body, including [QUERY](#http-query-method).
 
 
 ### [Override Method (PUT, PATCH, DELETE from Forms)](#override-method-put-patch-delete-from-forms)
@@ -570,8 +615,8 @@ _Important note: This should **not** be used by plugins/addons, instead they sho
 
 Available filters:
 
- - before\_all, before\_get, before\_post, before\_put, before\_patch, before\_delete
- - after\_all, after\_get, after\_post, after\_put, after\_patch, after\_delete
+ - before\_all, before\_get, before\_post, before\_put, before\_patch, before\_delete, before\_options, before\_query
+ - after\_all, after\_get, after\_post, after\_put, after\_patch, after\_delete, after\_options, after\_query
 
 The `Filter` middleware is lazily added as soon as a call to `after_X` or `before_X` is made. It will __not__ even be instantiated unless a call to `after_X` or `before_X` is made.
 
@@ -1322,12 +1367,24 @@ require "./spec_helper"
 
 describe "Your::Kemal::App" do
 
-  # You can use get,post,put,patch,delete to call the corresponding route.
+  # You can use get,post,put,patch,delete,query to call the corresponding route.
   it "renders /" do
     get "/"
     response.body.should eq "Hello World!"
   end
 
+end
+```
+
+For a `QUERY` route, remember to send a `Content-Type` along with the body:
+
+```crystal
+it "searches" do
+  query "/search",
+    headers: HTTP::Headers{"Content-Type" => "application/json"},
+    body: {q: "crystal"}.to_json
+
+  response.status_code.should eq 200
 end
 ```
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -164,10 +164,51 @@ end
 delete "/" do
   "Deleting resource"
 end
+
+# QUERY - Read data with the query in the request body (RFC 10008)
+query "/" do
+  "Answering a query"
+end
 ```
 
 Any **string** returned from a route will output to the browser.
 Routes are matched in the order they are defined. The first route that matches the request is invoked.
+
+## HTTP QUERY Method
+
+`QUERY` ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008)) is a safe and idempotent method — like `GET` — that carries the query in the request body instead of the URL. It's a good fit when a search is too long, too structured, or too sensitive to sit in a query string.
+
+```crystal
+require "kemal"
+
+query "/search" do |env|
+  # For "Content-Type: application/json"
+  q = env.params.json["q"]?.to_s
+
+  # For "Content-Type: application/x-www-form-urlencoded"
+  # q = env.params.body["q"]?.to_s
+
+  env.json({query: q, results: [] of String})
+end
+
+Kemal.run
+```
+
+Try it with `curl`:
+
+```bash
+curl -X QUERY http://localhost:3000/search \
+  -H "Content-Type: application/json" \
+  -d '{"q": "crystal"}'
+```
+
+Things to keep in mind:
+
+- `QUERY` is safe and idempotent, so the handler must not change server state. Use `POST` when the request has side effects.
+- A `QUERY` request that has a body but no `Content-Type` header is rejected with `400` by Kemal, as the RFC requires the content to carry a media type.
+- Deciding whether a query format is supported (`415`), acceptable (`406`), or processable (`422`) is up to your handler. You can advertise the formats you accept with the `Accept-Query` response header.
+- `QUERY` is not a CORS-safelisted method, so browsers always send a preflight request for it.
+- `before_query` / `after_query` filters and `Kemal::Router#query` work like every other verb.
 
 ## Kemal::Router (Modular Routing)
 
@@ -263,6 +304,8 @@ end
 ```
 
 **NOTE:** For Array or Hash like parameters, Kemal will group like keys for you. Alternatively, you can use the square bracket notation `likes[]=ruby&likes[]=crystal`. Be sure to access the param name exactly how it was passed. (i.e. `env.params.body["likes[]"]`).
+
+**NOTE:** `env.params.json` and `env.params.body` work the same way for any method with a body, including QUERY.
 
 ## Override Method (PUT, PATCH, DELETE from Forms)
 
@@ -518,8 +561,8 @@ _Important note: This should **not** be used by plugins/addons, instead they sho
 
 Available filters:
 
-- before_all, before_get, before_post, before_put, before_patch, before_delete
-- after_all, after_get, after_post, after_put, after_patch, after_delete
+- before_all, before_get, before_post, before_put, before_patch, before_delete, before_options, before_query
+- after_all, after_get, after_post, after_put, after_patch, after_delete, after_options, after_query
 
 The `Filter` middleware is lazily added as soon as a call to `after_X` or `before_X` is made. It will not even be instantiated unless a call to `after_X` or `before_X` is made.
 
@@ -1181,6 +1224,16 @@ describe "Your::Kemal::App" do
   it "renders /" do
     get "/"
     response.body.should eq "Hello World!"
+  end
+
+  # get, post, put, patch, delete and query helpers are available.
+  # A QUERY body needs a Content-Type, otherwise Kemal responds with 400.
+  it "searches" do
+    query "/search",
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
+      body: {q: "crystal"}.to_json
+
+    response.status_code.should eq 200
   end
 end
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ Kemal.run
 ## Key Features
 
 - **High-performance by default**: Built on Crystal with a thin abstraction layer so you can serve a large number of requests with low latency and low memory footprint.
-- **Full REST & HTTP support**: Handle all HTTP verbs (GET, POST, PUT, PATCH, DELETE, etc.) with a straightforward routing DSL.
+- **Full REST & HTTP support**: Handle all HTTP verbs (GET, POST, PUT, PATCH, DELETE, QUERY, etc.) with a straightforward routing DSL.
 - **WebSocket, SSE & real-time**: First-class WebSocket and Server-Sent Events (`sse`) support for chats, dashboards, notifications and other real-time experiences.
 - **JSON-first APIs**: Native JSON handling makes building JSON APIs and microservices feel natural.
 - **Static assets made easy**: Serve static files (assets, uploads, SPA bundles) efficiently from the same application.
@@ -42,7 +42,7 @@ Kemal.run
 
 ## Core Concepts
 
-- [Routes](https://kemalcr.com/guide#routes) - HTTP method routing (GET, POST, PUT, DELETE, PATCH)
+- [Routes](https://kemalcr.com/guide#routes) - HTTP method routing (GET, POST, PUT, DELETE, PATCH, QUERY)
 - [Parameters](https://kemalcr.com/guide#http-parameters) - URL, query, and post parameters
 - [Context](https://kemalcr.com/guide#context) - Request/response context and storage
 - [Filters](https://kemalcr.com/guide#filters) - Before/after request filters


### PR DESCRIPTION
Kemal now ships a `query` route DSL, `before_query` / `after_query` filters and `Kemal::Router#query` (kemalcr/kemal#769).

- Add QUERY to the routes overview and a dedicated section covering the RFC semantics: safe/idempotent handlers, the 400 for a body without a `Content-Type`, app-owned 415/406/422 + `Accept-Query`, CORS preflight.
- Complete the filter list with `before_query` / `after_query` (and the previously missing `before_options` / `after_options`).
- Note that `env.params.json` / `env.params.body` also cover QUERY.
- Mention the `query` spec-kemal helper in the testing section.
- Mirror all of it into `llms.txt` / `llms-full.txt`.